### PR TITLE
Fix json/spl dependencies

### DIFF
--- a/php_ds.c
+++ b/php_ds.c
@@ -69,8 +69,16 @@ PHP_MINFO_FUNCTION(ds)
     php_info_print_table_end();
 }
 
+static const zend_module_dep ds_deps[] = {
+    ZEND_MOD_REQUIRED("json")
+    ZEND_MOD_REQUIRED("spl")
+    ZEND_MOD_END
+};
+
 zend_module_entry ds_module_entry = {
-    STANDARD_MODULE_HEADER,
+    STANDARD_MODULE_HEADER_EX,
+    NULL,
+    ds_deps,
     "ds",
     NULL,
     PHP_MINIT(ds),

--- a/php_ds.h
+++ b/php_ds.h
@@ -13,7 +13,7 @@
 #include "ext/spl/spl_iterators.h"
 #include "ext/spl/spl_exceptions.h"
 #include "zend_smart_str.h"
-#include "json/php_json.h"
+#include "ext/json/php_json.h"
 
 extern zend_module_entry ds_module_entry;
 


### PR DESCRIPTION
Fix json header include and specify dependencies to enforce module
loading order. Otherwise an in-tree build will fail.