### PR TITLE
Reset the lookup table so that the htable can be used after it is cleared

### DIFF
--- a/src/ds/ds_htable.c
+++ b/src/ds/ds_htable.c
@@ -495,6 +495,8 @@ void ds_htable_clear(ds_htable_t *table)
         ds_htable_realloc(table, DS_HTABLE_MIN_CAPACITY);
     }
 
+    ds_htable_reset_lookup(table);
+
     table->min_deleted = table->capacity;
 }
 


### PR DESCRIPTION
The htable lookup table is not reset after it was cleared, so indices to invalid data were left in memory. This PR seems to fix #94.