### PR TITLE
Change test suite to 2.0.x-dev tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require-dev": {
-        "php-ds/tests": "^1.1"
+        "php-ds/tests": "2.0.x-dev"
     },
     "scripts": {
         "test"   : "php test.php",


### PR DESCRIPTION
The 1.1.x test suite errors out on just about every test. The 2.0.x passes a lot of the tests and might help move things along.