### PR TITLE
Fix #88 use correct type for variadic

### DIFF
--- a/src/php/parameters.h
+++ b/src/php/parameters.h
@@ -51,12 +51,12 @@ PARSE_2("zl", &z, &l)
 
 #define PARSE_VARIADIC_ZVAL() \
 zval *argv = NULL; \
-zend_long argc = 0; \
+int argc = 0; \
 PARSE_2("*", &argv, &argc)
 
 #define PARSE_LONG_AND_VARIADIC_ZVAL(_l) \
 zval *argv = NULL; \
-zend_long argc = 0; \
+int argc = 0; \
 zend_long _l = 0; \
 PARSE_3("l*", &_l, &argv, &argc)
 


### PR DESCRIPTION
See in Zend_API.c

```
	int *n_varargs = NULL;
			n_varargs = va_arg(*va, int *);
```

So this raise very bad memory corruption, critical on bigendian.

Here is test build in Fedora infra, using 1.2.2 + this patch
https://koji.fedoraproject.org/koji/taskinfo?taskID=21124193

For all architectures (i386, x86_64, **ppc64**, ppc64le, **s390x**, armv6hl, aarch64) build ok + test suite passes.
You can see the build.log in each sub-task.
