### PR TITLE
Improve float/double hash values

### DIFF
--- a/src/ds/ds_htable.c
+++ b/src/ds/ds_htable.c
@@ -249,6 +249,17 @@ static inline uint32_t get_resource_hash(zval *resource)
     return Z_RES_HANDLE_P(resource);
 }
 
+static inline uint32_t get_double_hash(zval *value)
+{
+    union ulld {
+        unsigned long long ull;
+        double d;
+    } hack;
+
+    hack.d = Z_DVAL_P(value);
+    return (uint32_t)(hack.ull ^ (hack.ull >> 32));
+}
+
 static uint32_t get_object_hash(zval *obj)
 {
     if (implements_hashable(obj)) {
@@ -260,7 +271,7 @@ static uint32_t get_object_hash(zval *obj)
                 return Z_LVAL(hash);
 
             case IS_DOUBLE:
-                return zval_get_long(&hash);
+                return get_double_hash(&hash);
 
             case IS_STRING:
                 return get_string_zval_hash(&hash);
@@ -289,7 +300,7 @@ static uint32_t get_hash(zval *value)
             return Z_LVAL_P(value);
 
         case IS_DOUBLE:
-            return zval_get_long(value);
+            return get_double_hash(value);
 
         case IS_STRING:
             return get_string_zval_hash(value);

--- a/src/ds/ds_htable.c
+++ b/src/ds/ds_htable.c
@@ -257,6 +257,10 @@ static inline uint32_t get_double_hash(zval *value)
     } hack;
 
     hack.d = Z_DVAL_P(value);
+    if (hack.d == -0.0) {
+        hack.d = 0.0;
+    }
+
     return (uint32_t)(hack.ull ^ (hack.ull >> 32));
 }
 


### PR DESCRIPTION
Right now the hash value for floats is their integer component. Instead, use dark magic to map the bits to an int.

Simple test script:
```php
<?php
$map = new \Ds\Map();

for ($ii = 0, $max = 100000; $ii < $max; ++$ii) {
    $map[($ii / $max)] = $ii;
}
```

Time before patch: 16.721446990967
Time with patch: 0.012161016464233