### PR TITLE
Use spl_object_id instead of spl_object_hash to provide object hash values

### DIFF
--- a/src/ds/ds_htable.c
+++ b/src/ds/ds_htable.c
@@ -237,11 +237,7 @@ static uint32_t get_array_hash(zval *array)
 
 static inline uint32_t get_spl_object_hash(zval *obj)
 {
-    zend_string *str = php_spl_object_hash(obj);
-    uint32_t hash = get_string_hash(str);
-    zend_string_free(str);
-
-    return hash;
+    return Z_OBJ_HANDLE_P(obj);
 }
 
 static inline uint32_t get_resource_hash(zval *resource)


### PR DESCRIPTION
This provides a significant speed boost on the Set::add benchmark (for 2**20 values the time went from 240ms to 100ms on my machine)