### PR TITLE
feat: req php 8.3+ and bump php-ds/tests to ^1.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "7.4"
-          - "8.0"
-          - "8.1"
-          - "8.2"
           - "8.3"
           - "8.4"
         phpts: ["ts", "nts"]

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">= 7.4.0"
+        "php": "^8.3"
     },
     "require-dev": {
-        "php-ds/tests": "^1.5"
+        "php-ds/tests": "^1.6"
     },
     "scripts": {
         "test"   : "php test.php",

--- a/package.xml
+++ b/package.xml
@@ -153,7 +153,7 @@
     <dependencies>
         <required>
             <php>
-                <min>7.4.0</min>
+                <min>8.3.0</min>
             </php>
             <pearinstaller>
                 <min>1.4.0b1</min>

--- a/test.php
+++ b/test.php
@@ -16,8 +16,9 @@ if (getenv('ENABLE_OPCACHE')) {
     }
 }
 
-// So that PHPUnit doesn't use "exit"
-$status = \PHPUnit\TextUI\Command::main(false);
+// Run PHPUnit without letting it call exit() itself
+$application = new \PHPUnit\TextUI\Application();
+$status = $application->run($_SERVER['argv']);
 
 // Attempt to collect anything left over from the tests.
 gc_collect_cycles();


### PR DESCRIPTION
Is there a reason to work with old php versions? The ext-ds versions for them have already been released.